### PR TITLE
Fix Crash on deserialize

### DIFF
--- a/VRCWS/Client.cs
+++ b/VRCWS/Client.cs
@@ -12,7 +12,7 @@ using UnhollowerRuntimeLib;
 using UnityEngine.Events;
 using System;
 
-[assembly: MelonInfo(typeof(VRCWSLibaryMod), "VRCWSLibary", "1.0.11", "Eric van Fandenfart")]
+[assembly: MelonInfo(typeof(VRCWSLibaryMod), "VRCWSLibary", "1.0.12", "Eric van Fandenfart")]
 [assembly: MelonGame]
 [assembly: MelonAdditionalDependencies("VRChatUtilityKit")]
 
@@ -36,7 +36,15 @@ namespace VRCWSLibary
 
         public T GetContentAs<T>()
         {
-            return JsonConvert.DeserializeObject<T>(Content);
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(Content);
+            }
+            catch (Exception)
+            {
+                //an invalid packed was tryed to be parsed. return null and let using function deal with it
+                return default;
+            }
         }
     }
     public class AcceptedMethod

--- a/VRCWS/Connection.cs
+++ b/VRCWS/Connection.cs
@@ -127,7 +127,16 @@ namespace VRCWSLibary
         public void Recieve(object sender, MessageEventArgs e)
         {
             //MelonLogger.Msg(e.Data);
-            Message msg = JsonConvert.DeserializeObject<Message>(e.Data);
+            Message msg = null;
+            try
+            {
+                msg = JsonConvert.DeserializeObject<Message>(e.Data);
+            }
+            catch (Exception)
+            {
+                //should never happen as message is always send by client. Maybe if client and server have diffrent versions
+                return;
+            }
             Client.OnMessage(msg);
 
             if (msg.Method == "OnlineStatus")


### PR DESCRIPTION
Json.deserialize will throw exception when invalid data is recieved not matching the expected data types